### PR TITLE
feat: add workspace endpoints to n8n app

### DIFF
--- a/nodes/Steuerboard/Steuerboard.node.ts
+++ b/nodes/Steuerboard/Steuerboard.node.ts
@@ -1,5 +1,6 @@
 import { type INodeType, type INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
 import { clientDescription } from './resources/client';
+import { workspaceDescription } from './resources/workspace';
 import { STEUERBOARD_API_URL } from './shared/constants';
 
 export class Steuerboard implements INodeType {
@@ -44,10 +45,15 @@ export class Steuerboard implements INodeType {
 						name: 'Client',
 						value: 'client',
 					},
+					{
+						name: 'Workspace',
+						value: 'workspace',
+					},
 				],
 				default: 'client',
 			},
 			...clientDescription,
+			...workspaceDescription,
 		],
 	};
 }

--- a/nodes/Steuerboard/resources/client/index.ts
+++ b/nodes/Steuerboard/resources/client/index.ts
@@ -11,19 +11,6 @@ const showOnlyForClients = {
 
 export const clientDescription: INodeProperties[] = [
 	{
-		displayName: 'Resource',
-		name: 'resource',
-		type: 'options',
-		noDataExpression: true,
-		options: [
-			{
-				name: 'Client',
-				value: RESOURCE.CLIENT,
-			},
-		],
-		default: RESOURCE.CLIENT,
-	},
-	{
 		displayName: 'Operation',
 		name: 'operation',
 		type: 'options',

--- a/nodes/Steuerboard/resources/workspace/get.ts
+++ b/nodes/Steuerboard/resources/workspace/get.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties } from 'n8n-workflow';
+import { OPERATION, RESOURCE } from '../../shared/constants';
+
+const showOnlyForWorkspaceGet = {
+	operation: [OPERATION.GET],
+	resource: [RESOURCE.WORKSPACE],
+};
+
+export const workspaceGetDescription: INodeProperties[] = [
+	{
+		displayName: 'Client ID',
+		name: 'clientId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the client',
+		displayOptions: { show: showOnlyForWorkspaceGet },
+	},
+	{
+		displayName: 'Workspace ID',
+		name: 'workspaceId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the workspace to get',
+		displayOptions: { show: showOnlyForWorkspaceGet },
+		routing: {
+			send: {
+				type: 'query',
+				property: 'workspaceId',
+			},
+		},
+	},
+];

--- a/nodes/Steuerboard/resources/workspace/index.ts
+++ b/nodes/Steuerboard/resources/workspace/index.ts
@@ -1,0 +1,57 @@
+/* eslint-disable n8n-nodes-base/node-param-default-missing */
+
+import type { INodeProperties } from 'n8n-workflow';
+import { OPERATION, RESOURCE } from '../../shared/constants';
+import { workspaceGetDescription } from './get';
+import { workspaceListDescription } from './list';
+
+const showOnlyForWorkspaces = {
+	resource: [RESOURCE.WORKSPACE],
+};
+
+export const workspaceDescription: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: showOnlyForWorkspaces,
+		},
+		options: [
+			{
+				name: 'List',
+				value: OPERATION.LIST,
+				action: 'List workspaces',
+				description: 'Returns a list of workspaces',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '=/v1/workspaces',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
+					},
+				},
+			},
+			{
+				name: 'Get by ID',
+				value: OPERATION.GET,
+				action: 'Get a workspace by ID',
+				description: 'Returns a single workspace object by ID',
+				routing: {
+					request: {
+						method: 'GET',
+						url: '=/v1/workspaces/{{$parameter.workspaceId}}',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
+					},
+				},
+			},
+		],
+		default: OPERATION.LIST,
+	},
+	...workspaceListDescription,
+	...workspaceGetDescription,
+];

--- a/nodes/Steuerboard/resources/workspace/list.ts
+++ b/nodes/Steuerboard/resources/workspace/list.ts
@@ -1,0 +1,110 @@
+import type { INodeProperties } from 'n8n-workflow';
+import { OPERATION, RESOURCE } from '../../shared/constants';
+
+const showOnlyForWorkspaceList = {
+	operation: [OPERATION.LIST],
+	resource: [RESOURCE.WORKSPACE],
+};
+
+export const workspaceListDescription: INodeProperties[] = [
+	{
+		displayName: 'Client ID',
+		name: 'clientId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the client',
+		displayOptions: { show: showOnlyForWorkspaceList },
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				...showOnlyForWorkspaceList,
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 100,
+		},
+		default: 50,
+		routing: {
+			send: {
+				type: 'query',
+				property: 'limit',
+				value: '={{ $parameter.returnAll ? undefined : $value }}',
+			},
+			output: {
+				maxResults: '={{ $parameter.returnAll ? undefined : $value }}',
+			},
+		},
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: showOnlyForWorkspaceList,
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+		routing: {
+			send: {
+				paginate: '={{ $value }}',
+				type: 'query',
+				property: 'limit',
+				value: "={{ $value ? '100' : undefined }}",
+			},
+			operations: {
+				pagination: {
+					type: 'generic',
+					properties: {
+						continue: '={{ !!($response.body.pagination?.nextCursor) }}',
+						request: {
+							url: '={{ $request.url }}',
+							qs: {
+								cursor: '={{ $response.body.pagination?.nextCursor }}',
+								limit: "={{ $parameter.returnAll ? '100' : undefined }}",
+							},
+							headers: {
+								'x-client-id': '={{ $parameter.clientId }}',
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		typeOptions: {
+			multipleValueButtonText: 'Add Filter',
+		},
+		displayOptions: {
+			show: showOnlyForWorkspaceList,
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Cursor',
+				name: 'cursor',
+				type: 'string',
+				default: '',
+				description: 'Cursor for pagination (used to get the next page of results)',
+				routing: {
+					request: {
+						qs: {
+							cursor: '={{$value}}',
+						},
+					},
+				},
+			},
+		],
+	},
+];

--- a/nodes/Steuerboard/resources/workspace/list.ts
+++ b/nodes/Steuerboard/resources/workspace/list.ts
@@ -80,31 +80,20 @@ export const workspaceListDescription: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Filters',
-		name: 'filters',
-		type: 'collection',
-		typeOptions: {
-			multipleValueButtonText: 'Add Filter',
-		},
+		displayName: 'Cursor',
+		name: 'cursor',
+		type: 'string',
+		default: '',
+		description: 'Cursor for pagination (used to get the next page of results)',
 		displayOptions: {
 			show: showOnlyForWorkspaceList,
 		},
-		default: {},
-		options: [
-			{
-				displayName: 'Cursor',
-				name: 'cursor',
-				type: 'string',
-				default: '',
-				description: 'Cursor for pagination (used to get the next page of results)',
-				routing: {
-					request: {
-						qs: {
-							cursor: '={{$value}}',
-						},
-					},
+		routing: {
+			request: {
+				qs: {
+					cursor: '={{ $value || undefined }}',
 				},
 			},
-		],
+		},
 	},
 ];

--- a/nodes/Steuerboard/shared/constants.ts
+++ b/nodes/Steuerboard/shared/constants.ts
@@ -2,6 +2,7 @@ export const STEUERBOARD_API_URL = 'http://localhost:5200';
 
 export const RESOURCE = {
 	CLIENT: 'client',
+	WORKSPACE: 'workspace',
 } as const;
 
 export const OPERATION = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Workspace resource to the Steuerboard node with "List" and "Get by ID" operations.
  * Added workspace-specific inputs: Client ID and Workspace ID where applicable.
  * Introduced pagination controls for listing workspaces (Return All, Limit) and a Cursor field for paging.
  * Resource dropdown now includes "Workspace" alongside "Client"; default remains "Client."
  * Workspace fields are shown contextually when Workspace is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->