### PR TITLE
fix: add missing client header to tasks

### DIFF
--- a/nodes/Steuerboard/resources/task/delete.ts
+++ b/nodes/Steuerboard/resources/task/delete.ts
@@ -8,6 +8,15 @@ const showOnlyForTaskDelete = {
 
 export const taskDeleteDescription: INodeProperties[] = [
 	{
+		displayName: 'Client ID',
+		name: 'clientId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the client',
+		displayOptions: { show: showOnlyForTaskDelete },
+	},
+	{
 		displayName: 'Task ID',
 		name: 'taskId',
 		type: 'string',

--- a/nodes/Steuerboard/resources/task/get.ts
+++ b/nodes/Steuerboard/resources/task/get.ts
@@ -8,6 +8,15 @@ const showOnlyForTaskGet = {
 
 export const taskGetDescription: INodeProperties[] = [
 	{
+		displayName: 'Client ID',
+		name: 'clientId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the client',
+		displayOptions: { show: showOnlyForTaskGet },
+	},
+	{
 		displayName: 'Task ID',
 		name: 'taskId',
 		type: 'string',

--- a/nodes/Steuerboard/resources/task/index.ts
+++ b/nodes/Steuerboard/resources/task/index.ts
@@ -32,6 +32,9 @@ export const taskDescription: INodeProperties[] = [
 					request: {
 						method: 'GET',
 						url: '=/tasks',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
 					},
 				},
 			},
@@ -44,6 +47,9 @@ export const taskDescription: INodeProperties[] = [
 					request: {
 						method: 'GET',
 						url: '=/tasks/{{$parameter.taskId}}',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
 					},
 				},
 			},
@@ -71,6 +77,9 @@ export const taskDescription: INodeProperties[] = [
 					request: {
 						method: 'PATCH',
 						url: '=/tasks/{{$parameter.taskId}}',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
 					},
 				},
 			},
@@ -83,6 +92,9 @@ export const taskDescription: INodeProperties[] = [
 					request: {
 						method: 'DELETE',
 						url: '=/tasks/{{$parameter.taskId}}',
+						headers: {
+							'x-client-id': '={{ $parameter.clientId }}',
+						},
 					},
 				},
 			},

--- a/nodes/Steuerboard/resources/task/list.ts
+++ b/nodes/Steuerboard/resources/task/list.ts
@@ -93,6 +93,9 @@ export const taskListDescription: INodeProperties[] = [
 								clientId: '={{ $parameter.clientId || undefined }}',
 								workspaceId: '={{ $parameter.workspaceId || undefined }}',
 							},
+							headers: {
+								'x-client-id': '={{ $parameter.clientId }}',
+							},
 						},
 					},
 				},

--- a/nodes/Steuerboard/resources/task/list.ts
+++ b/nodes/Steuerboard/resources/task/list.ts
@@ -12,12 +12,13 @@ export const taskListDescription: INodeProperties[] = [
 		name: 'clientId',
 		type: 'string',
 		default: '',
-		description: 'The ID of the client (optional filter)',
+		required: true,
+		description: 'The ID of the client',
 		displayOptions: { show: showOnlyForTaskList },
 		routing: {
 			request: {
 				qs: {
-					clientId: '={{ $value || undefined }}',
+					clientId: '={{ $value }}',
 				},
 			},
 		},

--- a/nodes/Steuerboard/resources/task/update.ts
+++ b/nodes/Steuerboard/resources/task/update.ts
@@ -8,6 +8,15 @@ const showOnlyForTaskUpdate = {
 
 export const taskUpdateDescription: INodeProperties[] = [
 	{
+		displayName: 'Client ID',
+		name: 'clientId',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the client',
+		displayOptions: { show: showOnlyForTaskUpdate },
+	},
+	{
 		displayName: 'Task ID',
 		name: 'taskId',
 		type: 'string',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a required "Client ID" input to Task operations: List, Get, Update, Delete (appears before Task ID).
  * Task API requests now include an x-client-id header for List, Get, Update, and Delete (Create already included it).
  * Pagination "Return All" continuation requests for Task List send the x-client-id header to preserve client context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->